### PR TITLE
Add a dependency on sky_tools

### DIFF
--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -144,6 +144,7 @@ name: {{projectName}}
 description: {{description}}
 dependencies:
   sky: any
+  sky_tools: any
 ''';
 
 const _libMain = r'''

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sky_tools
-version: 0.0.8+2
+version: 0.0.8+3
 description: Tools for building Sky applications
 homepage: https://github.com/domokit/sky_tools
 author: Chromium Authors <sky-dev@googlegroups.com>


### PR DESCRIPTION
This is needed to make pub run sky_tools:sky_server work.
Partial fix for https://github.com/domokit/sky_engine/issues/539