### PR TITLE
use mockito in the init tests

### DIFF
--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -65,13 +65,10 @@ Or if the Sky APK is not already on your device, run:
       stdout.addStream(process.stdout);
       stderr.addStream(process.stderr);
       int code = await process.exitCode;
-      if (code == 0) {
-        print('\n${message}');
-      }
-    } else {
-      print(message);
-      return 2;
+      if (code != 0) return code;
     }
+
+    print(message);
     return 0;
   }
 }
@@ -146,6 +143,7 @@ name: {{projectName}}
 description: {{description}}
 dependencies:
   sky: any
+dev_dependencies:
   sky_tools: any
 ''';
 

--- a/test/init_test.dart
+++ b/test/init_test.dart
@@ -4,10 +4,12 @@
 
 import 'dart:io';
 
-import 'package:args/args.dart';
+import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as p;
 import 'package:sky_tools/src/init.dart';
 import 'package:test/test.dart';
+
+import 'src/common.dart';
 
 main() => defineTests();
 
@@ -26,10 +28,11 @@ defineTests() {
     // Verify that we create a project that is well-formed.
     test('init sky-simple', () async {
       InitCommandHandler handler = new InitCommandHandler();
-      _MockArgResults results = new _MockArgResults();
-      results.values['help'] = false;
-      results.values['pub'] = true;
-      results.values['out'] = temp.path;
+      MockArgResults results = new MockArgResults();
+      when(results['help']).thenReturn(false);
+      when(results['pub']).thenReturn(true);
+      when(results.wasParsed('out')).thenReturn(true);
+      when(results['out']).thenReturn(temp.path);
       await handler.processArgResults(results);
       String path = p.join(temp.path, 'lib/main.dart');
       expect(new File(path).existsSync(), true);
@@ -39,15 +42,4 @@ defineTests() {
       expect(exec.exitCode, 0);
     });
   });
-}
-
-class _MockArgResults implements ArgResults {
-  Map values = {};
-  operator [](String name) => values[name];
-  List<String> get arguments => null;
-  ArgResults get command => null;
-  String get name => null;
-  Iterable<String> get options => values.keys;
-  List<String> get rest => null;
-  bool wasParsed(String name) => values.containsKey(name);
 }

--- a/test/install_test.dart
+++ b/test/install_test.dart
@@ -4,10 +4,11 @@
 
 library install_test;
 
-import 'package:args/args.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sky_tools/src/install.dart';
 import 'package:test/test.dart';
+
+import 'src/common.dart';
 
 main() => defineTests();
 
@@ -22,10 +23,4 @@ defineTests() {
           .then((int code) => expect(code, equals(0)));
     });
   });
-}
-
-@proxy
-class MockArgResults extends Mock implements ArgResults {
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/src/common.dart
+++ b/test/src/common.dart
@@ -1,0 +1,12 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/args.dart';
+import 'package:mockito/mockito.dart';
+
+@proxy
+class MockArgResults extends Mock implements ArgResults {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
- have `init_test.dart` use mockito (as well as `install_test`)
- pass through error codes from pub if that fails for the `init` command
- move the `sky_tools` dependency on our generated sample to a dev_dependency

@iansf 