### PR TITLE
Prepend mojo shebang to skyx files

### DIFF
--- a/lib/src/build.dart
+++ b/lib/src/build.dart
@@ -174,7 +174,8 @@ class BuildCommandHandler extends CommandHandler {
     }
 
     File outputFile = new File(results['output-file']);
-    await outputFile.writeAsBytes(new ZipEncoder().encode(archive));
+    await outputFile.writeAsString('#!mojo mojo:sky_viewer\n')
+    await outputFile.writeAsBytes(new ZipEncoder().encode(archive), mode: FileMode.APPEND);
     return 0;
   }
 }


### PR DESCRIPTION
skyx files are zips, so they can have anything at the start. Having
a shebang line at the start makes it easier to run skyx files in a mojo
environment.