### PR TITLE
Download sky_snapshot from the cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 artifacts
 packages
 pubspec.lock
+/lib/cache/

--- a/lib/src/artifacts.dart
+++ b/lib/src/artifacts.dart
@@ -8,15 +8,52 @@ import 'dart:async';
 import 'dart:io';
 
 enum Artifact {
-  FlutterCompiler
+  FlutterCompiler,
 }
 
 class _ArtifactStore {
   _ArtifactStore._();
 
-  Future<File> getPath(Artifact artifact) async {
-    // TODO(abarth): Download artifacts from cloud storage.
-    return new File('');
+  Future _downloadFile(String url, File file) async {
+      HttpClient httpClient = new HttpClient();
+      HttpClientRequest request = await httpClient.getUrl(Uri.parse(url));
+      HttpClientResponse response = await request.close();
+      if (response.statusCode != 200) throw new Exception(response.reasonPhrase);
+      IOSink sink = file.openWrite();
+      await sink.addStream(response);
+      await sink.close();
+  }
+
+  Future<String> _getEngineRevision(String packageRoot) {
+    return new File(packageRoot + '/sky_engine/REVISION').readAsString();
+  }
+
+  Future<Directory> _cacheDir(String engineRevision, String packageRoot) async {
+    String cacheDirPath = '${packageRoot}/sky_tools/cache/sky_engine/${engineRevision}/';
+    Directory cacheDir = new Directory(cacheDirPath);
+    if (!await cacheDir.exists()) {
+      await cacheDir.create(recursive: true);
+    }
+    return cacheDir;
+  }
+
+  Future<String> getPath(Artifact artifact, String packageRoot) async {
+    String engineRevision = await _getEngineRevision(packageRoot); 
+    Directory cacheDir = await _cacheDir(engineRevision, packageRoot);
+
+    if (artifact == Artifact.FlutterCompiler) {
+      File skySnapshotFile = new File(cacheDir.path + 'sky_snapshot');
+      if (!await skySnapshotFile.exists()) {
+        print('Downloading sky_snapshot from the cloud, one moment please...');
+        String googleStorageUrl = 'https://storage.googleapis.com/mojo/sky/shell/linux-x64/${engineRevision}/sky_snapshot';
+        await _downloadFile(googleStorageUrl, skySnapshotFile);
+        ProcessResult result = await Process.run('chmod', ['u+x', skySnapshotFile.path]);
+        if (result.exitCode != 0) throw new Exception(result.stderr);
+      }
+      return skySnapshotFile.path;
+    }
+
+    return '';
   }
 }
 

--- a/lib/src/build.dart
+++ b/lib/src/build.dart
@@ -105,10 +105,9 @@ Future _compileSnapshot({
   String packageRoot,
   String snapshotPath
 }) async {
-  File compiler = compilerPath == null ?
-      await artifactStore.getPath(Artifact.FlutterCompiler) :
-      new File(compilerPath);
-  ProcessResult result = await Process.run(compiler.path, [
+  if (compilerPath == null)
+      compilerPath = await artifactStore.getPath(Artifact.FlutterCompiler, packageRoot);
+  ProcessResult result = await Process.run(compilerPath, [
     mainPath,
     '--package-root=$packageRoot',
     '--snapshot=$snapshotPath'


### PR DESCRIPTION
This adds logic to download and use the sky_snapshot binary from
Google cloud storage when running the 'sky_tools build' command.
The downloaded binary is put into lib/cache/... The binary is
chosen to match the REVISION in the sky_engine package in the
packages directory of whichever package the user wishes to
build a flx from.

Known issues:
*) Assumes linux-x64 host
*) Assumes download will always produce valid executable
*) No clearing of stale cache entries